### PR TITLE
fix: rename class to `AtlassianPluginSdk8210`

### DIFF
--- a/atlassian-plugin-sdk8210.rb
+++ b/atlassian-plugin-sdk8210.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Atlassian Plugin SDK formula
-class AtlassianPluginSdk < Formula
+class AtlassianPluginSdk8210 < Formula
   desc "Set of tools and dependencies for plugins on Atlassian server applications"
   homepage "https://developer.atlassian.com/display/DOCS/Atlassian+Plugin+SDK+Documentation"
   url "https://packages.atlassian.com/mvn/maven-external/com/atlassian/amps/atlassian-plugin-sdk/8.2.10/atlassian-plugin-sdk-8.2.10.tar.gz"


### PR DESCRIPTION
This PR fixes the `8.2.10` class name

I get an error when I try to install `8.2.10` via brew:

```sh
brew install atlassian/tap/atlassian-plugin-sdk8210
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Error: No available formula with the name "atlassian/tap/atlassian-plugin-sdk8210". Did you mean atlassian/tap/atlassian-plugin-sdk827, atlassian/tap/atlassian-plugin-sdk, atlassian/tap/atlassian-plugin-sdk62, atlassian/tap/atlassian-plugin-sdk5 or atlassian/tap/atlassian-plugin-sdk4?
In formula file: /opt/homebrew/Library/Taps/atlassian/homebrew-tap/atlassian-plugin-sdk8210.rb
Expected to find class AtlassianPluginSdk8210, but only found: AtlassianPluginSdk.
```