### PR TITLE
Update atlassian-plugin-sdk to 9.11.2

### DIFF
--- a/atlassian-plugin-sdk@9.11.2.rb
+++ b/atlassian-plugin-sdk@9.11.2.rb
@@ -1,12 +1,14 @@
 # typed: false
 # frozen_string_literal: true
 
-# Atlassian Plugin SDK formula
-class AtlassianPluginSdk < Formula
+# Atlassian Plugin SDK formula, pinned to 9.11.2
+class AtlassianPluginSdkAT9112 < Formula
   desc "Set of tools and dependencies for plugins on Atlassian server applications"
   homepage "https://developer.atlassian.com/display/DOCS/Atlassian+Plugin+SDK+Documentation"
   url "https://packages.atlassian.com/mvn/maven-external/com/atlassian/amps/atlassian-plugin-sdk/9.11.2/atlassian-plugin-sdk-9.11.2.tar.gz"
   sha256 "5b1060dbc1224dd3cfeb3ffcb6e30d3eb0020af6c8e698c2b02d07a779e4b20b"
+
+  keg_only :versioned_formula
 
   def install
     # Remove windows files

--- a/atlassian-plugin-sdk@9.9.1.rb
+++ b/atlassian-plugin-sdk@9.9.1.rb
@@ -1,12 +1,14 @@
 # typed: false
 # frozen_string_literal: true
 
-# Atlassian Plugin SDK formula
-class AtlassianPluginSdk < Formula
+# Atlassian Plugin SDK formula, pinned to 9.9.1
+class AtlassianPluginSdkAT991 < Formula
   desc "Set of tools and dependencies for plugins on Atlassian server applications"
   homepage "https://developer.atlassian.com/display/DOCS/Atlassian+Plugin+SDK+Documentation"
-  url "https://packages.atlassian.com/mvn/maven-external/com/atlassian/amps/atlassian-plugin-sdk/9.11.2/atlassian-plugin-sdk-9.11.2.tar.gz"
-  sha256 "5b1060dbc1224dd3cfeb3ffcb6e30d3eb0020af6c8e698c2b02d07a779e4b20b"
+  url "https://packages.atlassian.com/mvn/maven-external/com/atlassian/amps/atlassian-plugin-sdk/9.9.1/atlassian-plugin-sdk-9.9.1.tar.gz"
+  sha256 "eacbed1b093d77efe2a4f1f2ff5902439932b75bfdb9a4f08d8bfafe77024ad7"
+
+  keg_only :versioned_formula
 
   def install
     # Remove windows files


### PR DESCRIPTION
## What

Updates the main `atlassian-plugin-sdk` formula from 9.9.1 to 9.11.2 —
the latest release per maven-metadata.xml and the Marketplace version
history (released 2026-01-19).

The sha256 matches the checksum published next to the artifact:
`5b1060dbc1224dd3cfeb3ffcb6e30d3eb0020af6c8e698c2b02d07a779e4b20b`

## Versioned formulae

Two pinned formulae are added alongside the update:

- `atlassian-plugin-sdk@9.9.1` — keeps the previous version installable,
  as done for earlier releases
- `atlassian-plugin-sdk@9.11.2` — added proactively so the next release
  only needs the main formula bumped

They use Homebrew's standard `@`-versioning instead of the existing
`atlassian-plugin-sdkNNN` pattern, for two reasons:

1. Squashing version digits is ambiguous: 9.11.2, 9.1.12 and 91.1.2
   would all collide as `sdk9112`.
2. Distinct class names (`AtlassianPluginSdkAT9112`) fix the duplicate
   `AtlassianPluginSdk` class issue that `brew audit` flags (see #19).

Both are marked `keg_only :versioned_formula` so they don't conflict
with the main formula when installed side by side.

Existing `sdkNNN` formulae are left untouched to keep this PR focused;
they could be migrated separately.

## Testing

- `brew style` / `brew audit` — clean on all three formulae
- Installed locally: `atlas-version` reports ATLAS 9.11.2 / AMPS 9.11.2